### PR TITLE
Fix typo in project README

### DIFF
--- a/project/README.md
+++ b/project/README.md
@@ -9,7 +9,7 @@
 
 - local.wolo.codes - 127.0.0.1
 
-## Project stcuture
+## Project structure
 
 ```
 Web


### PR DESCRIPTION
## Summary
- correct a typo in the project README header

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_686d66a00c1c8320abd49d1ad9553126