### PR TITLE
Fix cp path quoting and test spaces

### DIFF
--- a/project/render.sh
+++ b/project/render.sh
@@ -11,7 +11,7 @@ copy_dot_dirs() {
   
   shopt -s extglob
 
-  cp -r $source_dir/* $dest_dir
+  cp -r "$source_dir"/* "$dest_dir"
   for dir in "$source_dir"/.!(.|git); do
     if [ -d "$dir" ] || [ -f "$dir" ]; then
       cp -r "$dir" "$dest_dir"


### PR DESCRIPTION
## Summary
- fix quoting for `cp` command in `project/render.sh`
- tested copy function with paths containing spaces

## Testing
- `source <(sed -n '7,20p' project/render.sh); copy_dot_dirs "test src" "test dest"`
- `ls -R "test dest"`

------
https://chatgpt.com/codex/tasks/task_e_686d6ee8dbc883208b40f7f89b01d5ae