### PR TITLE
Fix YAML and script warnings

### DIFF
--- a/firebase/compose-dev.yaml
+++ b/firebase/compose-dev.yaml
@@ -1,13 +1,14 @@
+---
 services:
   firebase:
     entrypoint:
-    - sleep
-    - infinity
+      - sleep
+      - infinity
     image: node:20.11-slim
     init: true
     volumes:
-    - ../project/build:/app
-    - type: bind
-      source: /var/run/docker.sock
-      target: /var/run/docker.sock
+      - ../project/build:/app
+      - type: bind
+        source: /var/run/docker.sock
+        target: /var/run/docker.sock
     build: ./

--- a/project/compose-dev.yaml
+++ b/project/compose-dev.yaml
@@ -1,3 +1,4 @@
+---
 services:
 
   web-site:
@@ -14,7 +15,7 @@ services:
       - "local.cutie.codes:127.0.0.1"
       - "interim.cutie.codes:127.0.0.1"
       - "public.cutie.codes:127.0.0.1"
-    #restart: always
+    # restart: always
     networks:
       dan:
         ipv4_address: 10.8.0.2
@@ -35,13 +36,13 @@ services:
       - "443:443"
     depends_on:
       - web-site
-    #restart: always
+    # restart: always
     networks:
       - dan
-      
+
 networks:
   dan:
     driver: bridge
     ipam:
-     config:
-       - subnet: 10.8.0.0/24
+      config:
+        - subnet: 10.8.0.0/24

--- a/project/render.sh
+++ b/project/render.sh
@@ -2,7 +2,7 @@
 
 /app/tiggu/build.sh /app/site/project
 
-cd /app
+cd /app || exit
 
 shopt -s extglob
 copy_dot_dirs() {


### PR DESCRIPTION
## Summary
- clean up YAML formatting in docker compose files
- add fail-safe when changing directories in `render.sh`

## Testing
- `yamllint firebase/compose-dev.yaml project/compose-dev.yaml`
- `shellcheck project/render.sh`


------
https://chatgpt.com/codex/tasks/task_e_686d703fee6c8320acfba248bff54642